### PR TITLE
Cycle: disable tokenizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "compositephp/db": "0.4.2",
         "cycle/orm": "2.6",
         "cycle/annotated": "3.4",
-        "cycle/entity-behavior": "1.2",
         "doctrine/orm": "2.17.2",
         "illuminate/database": "10.38.2",
         "vlucas/phpdotenv": "5.6.0",

--- a/src/Cycle/User.php
+++ b/src/Cycle/User.php
@@ -2,23 +2,14 @@
 
 namespace App\Cycle;
 
-use Cycle\Annotated\Annotation\Column;
-use Cycle\Annotated\Annotation\Entity;
-
-#[Entity(table: 'Users', database: 'default')]
 class User
 {
-    #[Column(type: 'primary')]
     private int $id;
 
     public function __construct(
-        #[Column(type: 'string')]
         private string $name,
-        #[Column(type: 'integer')]
         private int $age,
-        #[Column(type: 'float')]
         private float $microtime,
-        #[Column(type: 'timestamp')]
         private \DateTimeImmutable $created_at = new \DateTimeImmutable(),
     ) {}
 

--- a/src/test-cycle.php
+++ b/src/test-cycle.php
@@ -1,9 +1,8 @@
 <?php declare(strict_types=1);
+
 include 'init.php';
 
 use App\Cycle\User;
-use Cycle\Schema;
-use Cycle\Annotated;
 use Cycle\Database;
 use Cycle\Database\Config;
 use Cycle\ORM;
@@ -29,25 +28,21 @@ $dbal = new Database\DatabaseManager(
     ])
 );
 
-$finder = (new \Symfony\Component\Finder\Finder())->files()->in([__DIR__ . '/Cycle']); // __DIR__ here is folder with entities
-$classLocator = new \Spiral\Tokenizer\ClassLocator($finder);
-
-$schema = (new Schema\Compiler())->compile(new Schema\Registry($dbal), [
-    new Schema\Generator\ResetTables(),             // re-declared table schemas (remove columns)
-    new Annotated\Embeddings($classLocator),        // register embeddable entities
-    new Annotated\Entities($classLocator),          // register annotated entities
-    new Annotated\TableInheritance(),               // register STI/JTI
-    new Annotated\MergeColumns(),                   // add @Table column declarations
-    new Schema\Generator\GenerateRelations(),       // generate entity relations
-    new Schema\Generator\GenerateModifiers(),       // generate changes from schema modifiers
-    new Schema\Generator\ValidateEntities(),        // make sure all entity schemas are correct
-    new Schema\Generator\RenderTables(),            // declare table schemas
-    new Schema\Generator\RenderRelations(),         // declare relation keys and indexes
-    new Schema\Generator\RenderModifiers(),         // render all schema modifiers
-    new Annotated\MergeIndexes(),                   // add @Table column declarations
-    new Schema\Generator\SyncTables(),              // sync table changes to database
-    new Schema\Generator\GenerateTypecast(),        // typecast non string columns
-]);
+$schema = [
+    'user' => [
+        ORM\SchemaInterface::ENTITY => User::class,
+        ORM\SchemaInterface::DATABASE => 'default',
+        ORM\SchemaInterface::TABLE => 'Users',
+        ORM\SchemaInterface::PRIMARY_KEY => ['id'],
+        ORM\SchemaInterface::COLUMNS => ['id', 'name', 'age', 'microtime', 'created_at'],
+        ORM\SchemaInterface::TYPECAST => [
+            'id' => 'int',
+            'age' => 'int',
+            'microtime' => 'float',
+            'created_at' => 'datetime',
+        ],
+    ],
+];
 $orm = new ORM\ORM(
     factory: new ORM\Factory($dbal),
     schema: new ORM\Schema($schema),


### PR DESCRIPTION
>  ORM Schema compilation usually doesn't run in a production environment, but is loaded from the cache. This can affect the Memory Peak metric.
Perhaps it would be more correct to set the schema manually, rather than parsing files and attributes. https://github.com/compositephp/php-orm-benchmark/pull/1#issuecomment-1869655828


Also removed unused packages.

I think the same is fair to do for Doctrine and Compositedb - to take out cache compilation. And in the startup script, use the ready result.
Then the Memory Peak metric will be collected under more equal conditions.